### PR TITLE
Add a guide on using data-role

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -31,6 +31,10 @@
 - [Avoid adding dummy data that is not asserted in the spec](samples/testing/2.rb)
 - Only enable `:js` when the feature absolutely requires javascript
 - [Prefer `have_text` over `have_content`](https://github.com/cookpad/global-digging/issues/2)
+- Prefer `data-role` attribute to [assert]/[count] element(s) over using class/ID in tests
+
+[assert]: samples/testing/4.md
+[count]: samples/testing/5.md
 
 ## I18n
 

--- a/best-practices/samples/testing/4.md
+++ b/best-practices/samples/testing/4.md
@@ -1,0 +1,45 @@
+# Assert element exists in tests
+
+## Given
+
+```html+erb
+<% unless browser.device.mobile? %>
+  <%= link_to download_path do %>
+    <%= image_tag static_image_url("in/banners/conversion/download-app.jpg"), class: "banner", alt: t("static_pages.download_links.title") %>
+  <% end %>
+<% end %>
+```
+
+## Bad
+
+### Add ID to the link
+
+```diff
+<% unless browser.device.mobile? %>
+  - <%= link_to download_path do %>
+  + <%= link_to download_path, id: "download-app" do %>
+    <%= image_tag static_image_url("in/banners/conversion/download-app.jpg"), class: "banner", alt: t("static_pages.download_links.title") %>
+  <% end %>
+<% end %>
+```
+
+```ruby
+expect(page).to have_css "a#download-app"
+```
+
+## Good
+
+### Add `data-role` to the link
+
+```diff
+<% unless browser.device.mobile? %>
+  - <%= link_to download_path do %>
+  + <%= link_to download_path, data: { role: "download-app" } do %>
+    <%= image_tag static_image_url("in/banners/conversion/download-app.jpg"), class: "banner", alt: t("static_pages.download_links.title") %>
+  <% end %>
+<% end %>
+```
+
+```ruby
+expect(page).to have_css %([data-role="download-app"])
+```

--- a/best-practices/samples/testing/5.md
+++ b/best-practices/samples/testing/5.md
@@ -1,0 +1,43 @@
+# Count elements in tests
+
+## Given
+
+```html
+<a class="btn btn--banner" id="top-download-banner">Download the App</a>
+...
+<a class="btn btn--banner">Get the App</a>
+...
+<footer>
+  <a class="btn btn--banner">Get the App</a>
+</footer>
+```
+
+## Bad
+
+### Count the number of "Get the App" links
+
+```ruby
+expect(page).to have_css("a#btn--banner:not(#top-download-banner)", count: 2)
+```
+
+## Good
+
+### Add `data-role` to the element
+
+```diff
+<a class="btn btn--banner" id="top-download-banner">Download the App</a>
+...
+- <a class="btn btn--banner">Get the App</a>
++ <a class="btn btn--banner" data-role="get-the-app-banner">Get the App</a>
+...
+<footer>
+  - <a class="btn btn--banner">Get the App</a>
+  + <a class="btn btn--banner" data-role="get-the-app-banner">Get the App</a>
+</footer>
+```
+
+### Count the number of get-the-app-banner banner
+
+```ruby
+expect(page).to have_css %([data-role="get-the-app-banner"]), count: 2
+```

--- a/best-practices/samples/testing/5.md
+++ b/best-practices/samples/testing/5.md
@@ -14,8 +14,6 @@
 
 ## Bad
 
-### Count the number of "Get the App" links
-
 ```ruby
 expect(page).to have_css("a#btn--banner:not(#top-download-banner)", count: 2)
 ```
@@ -35,8 +33,6 @@ expect(page).to have_css("a#btn--banner:not(#top-download-banner)", count: 2)
   + <a class="btn btn--banner" data-role="get-the-app-banner">Get the App</a>
 </footer>
 ```
-
-### Count the number of get-the-app-banner banner
 
 ```ruby
 expect(page).to have_css %([data-role="get-the-app-banner"]), count: 2


### PR DESCRIPTION
We use `data-role` to ~~decouple~~ distinguish our test logic from our ~~presentation
logic~~ UI specific / business domain logic. This way, we can change class, ID, and tags without breaking our tests.

See original discussion at: https://github.com/cookpad/global-web/issues/5046.

[Preview assert example](https://github.com/cookpad/guides/blob/fc3832a/best-practices/samples/testing/4.md)

[Preview count example](https://github.com/cookpad/guides/blob/fc3832a/best-practices/samples/testing/5.md)