### PR TITLE
Include specs in Rails/Output cop

### DIFF
--- a/linters/rubocop.yml
+++ b/linters/rubocop.yml
@@ -302,3 +302,12 @@ PercentLiteralDelimiters:
     "%w": ()
     "%W": ()
     "%x": ()
+
+Rails/Output:
+  Enabled: true
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - db/**/*.rb
+    - lib/**/*.rb
+    - spec/**/*.rb


### PR DESCRIPTION
Default configuration for `Rails/Output` cop is only checking some directories: 

```
$ rubocop --show-cop Rails/Output
Rails/Output:
  Description: Checks for calls to puts, print, etc.
  Enabled: true
  Include:
  - app/**/*.rb
  - config/**/*.rb
  - db/**/*.rb
  - lib/**/*.rb
```

I'd like to add `spec/**/*.rb` to that list