### PR TITLE
Disable SkipsModelValidations cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -316,3 +316,6 @@ Rails/Output:
     - db/**/*.rb
     - lib/**/*.rb
     - spec/**/*.rb
+
+Rails/SkipsModelValidations:
+  Enabled: false


### PR DESCRIPTION
Should be a case-by-case basis for this I think? If we need to mess with the DB directly it should be our prerogative 😅 

- http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/SkipsModelValidations
- https://github.com/cookpad/global-web/pull/5412#discussion_r121676698