### PR TITLE
Exclude special ruby files from BlockLength rule [Delivers #1prpIT5g]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
 Metrics/BlockLength:
   Exclude:
-    - spec/**/*
-    - config/routes*
+    - spec/**/*.rb
+    - config/**/*.rb
+    - lib/tasks/**/*.rake
+    - Gemfile
 
 Metrics/LineLength:
   AllowHeredoc: true


### PR DESCRIPTION
Trello: https://trello.com/c/1prpIT5g

In addition to specs, this change excludes special Ruby files that usually don't define Ruby classes with methods, but are mostly based on blocks: configuration files, initializers, rake tasks, etc.