### PR TITLE
Mention usage of CSS classes in tests as an anti-pattern

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -37,6 +37,7 @@
 - [Prefer `have_text` over `have_content`](https://groups.google.com/forum/#!topic/ruby-capybara/NH4HHEm7400)
 - [Prefer "descriptive" dummy data over realistic dummy data](samples/testing/4.rb)
 - [Do not use _should_ when describing your tests](samples/testing/5.rb)
+- [Avoid assertions tied to html classes](samples/testing/6.rb)
 
 ## I18n
 

--- a/best-practices/samples/testing/6.rb
+++ b/best-practices/samples/testing/6.rb
@@ -10,11 +10,11 @@ expect(page).to have_text("Recipe Title", count: 3)
 
 
 ## Bad
-within(".download-banner") do
+within(".android-download-banner") do
   expect(page).to have_text("Download Here")
 end
 
 ## Good
-within("#download_banner") do
+within("#android_download_banner") do
   expect(page).to have_text("Download Here")
 end

--- a/best-practices/samples/testing/6.rb
+++ b/best-practices/samples/testing/6.rb
@@ -1,0 +1,20 @@
+## Bad
+create_list(3, :recipe)
+visit recipes_path
+expect(page).to have_css(".recipe", count: 3)
+
+## Good
+create_list(3, :recipe, title: "Recipe Title")
+visit recipes_path
+expect(page).to have_text("Recipe Title", count: 3)
+
+
+## Bad
+within(".download-banner") do
+  expect(page).to have_text("Download Here")
+end
+
+## Good
+within("#download_banner") do
+  expect(page).to have_text("Download Here")
+end


### PR DESCRIPTION
After having thought of this for a while 💭  and actually digging into some of the specs that would be affected by https://github.com/cookpad/guides/pull/33 with @davidstosik, aaaand finally doing a bit of soul-searching around how clueless I am about accessibility/screen readers etc, I'm actually kind of reluctant to adopt using `data-role` as standard practice... 🤔 

Reasons are:

- More often than not, there is a way to test _without_ adding an extra `data-role` to the element (some examples in [this PR](https://github.com/cookpad/global-web/pull/5493))
- If there isn't, it _could_ be a sign of missing accessibility. For example [this icon](https://github.com/cookpad/global-web/blob/52aa8bde8dff0b936b8cdfac3dd4a8c756dbe7df/spec/features/likes_spec.rb#L102) could benefit from a `title` or `aria-label`, which would allow screen readers to pick it up
- Accessibility isn't something that's easy to do well, but relying on `data-role` as the go-to solution for specs could maybe cause us to overlook it even more
- One tool that _is_ hard to use without selectors, is `within`. However in this case you will often be wanting a single, unique thing on the page anyway, so perhaps html IDs are appropriate here?
- `aria` tags can actually make use of html IDs, so in that sense they might provide value in the future, even if originally added only for the tests to hook into

This doesn't answer every edge case out there, and will need to keep an eye on specs to see how to tackle different scenarios, but thinking that maybe for now, for the purpose of the guides, we could agree on specs hooking into CSS classes being a bad idea? 😅 

(thoughts welcome!)
