### PR TITLE
Do not push big files to GitHub

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -54,3 +54,4 @@
 
 - When syncing with master, if the branch is under PR review or being collaborated on,
   use `merge` instead of `rebase` to avoid losing relevant context/breaking other local branches
+- Avoid pushing temporary data files or big binary files to GitHub.


### PR DESCRIPTION
See title. :point_up:

I'd even like to suggest changing the wording in operations.md, from

> Don't commit large (15MB+) in the git repo itself!

to

> Avoid pushing temporary data files or big binary files to GitHub

If the file is a temporary data file (eg. CSV used in one-offs), or a big binary file (eg. GeoIP database), then it should not inflate the repository.

I even think it would be nice if we could prevent any big file (and/or extension?) to be pushed, before it happens, because if a file is pushed to the repository, then it is too late, and a [tedious repo cleaning](cookpad/global-web/issues/4777) is necessary to get rid of its weight.