### PR TITLE
EnforcedStyle: template 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -310,6 +310,8 @@ PercentLiteralDelimiters:
     "%w": ()
     "%W": ()
     "%x": ()
+  Exclude:
+    - spec/**/*
 
 Rails/Output:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -215,6 +215,9 @@ Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: no_comma
 
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 TrivialAccessors:
   Enabled: false
 
@@ -310,8 +313,6 @@ PercentLiteralDelimiters:
     "%w": ()
     "%W": ()
     "%x": ()
-  Exclude:
-    - spec/**/*
 
 Rails/Output:
   Enabled: true


### PR DESCRIPTION
#### Issue:
while working on https://github.com/cookpad/global-web/pull/5912 keep bumping to `%{something}` being check and mark as violated by hound.

#### This PR
~exclude spec from this delimiter checking to avoid a false positive issue~
EnforcedStyle: template to fix this issue

cc: @balvig 