### PR TITLE
The namespace of EmptyLines has changed to Layout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -295,7 +295,7 @@ Lint/UselessAssignment:
   Exclude:
     - spec/**/*
 
-Style/EmptyLines:
+Layout/EmptyLines:
   Exclude:
     - spec/**/*
 


### PR DESCRIPTION
A few months ago Hound updated the Rubocop version from 0.46.0 to the latest 0.49.1. With this new version our configuration is causing a warning to be displayed:

```
.rubocop-https---raw-githubusercontent-com-cookpad-guides-master--rubocop-yml: 
Style/EmptyLines has the wrong namespace - should be Layout
```

The namespace of `EmptyLines` was modified. This PR changes it to the new `Layout` namespace