### PR TITLE
CSS: Allow shorthand of 4

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -166,7 +166,6 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
 
   SingleLinePerProperty:
     enabled: true


### PR DESCRIPTION
First emerged from https://github.com/cookpad/global-web/pull/6008#discussion_r138271853

With this change it'll allow us to write `margin: 1px 2px 3px 4px` (although not likely we'd write it that way that much given we're putting more efforts to modularize and standardize the css), it is useful for particular cases.

Note that this rule does not suppress the warning of "should be written more concisely" 😉 

### Before

```scss
.one {
  margin: 1px;
}

.two {
  margin: 1px 2px;
}

.three {
  margin: 1px 2px 3px;
}

.four {
  margin: 1px 2px 3px 4px; // Boom: Shorthands of length `4` are not allowed. Value was `1px 2px 3px 4px`
}

.dumb {
  margin: 1px 1px 1px 1px; // Boom: Shorthands of length `4` are not allowed. Value was `1px 1px 1px 1px`
  // Boom 2: Shorthand form for property `margin` should be written more concisely as `1px` instead of `1px 1px 1px 1px`
}
```


### After
```scss
.one {
  margin: 1px;
}

.two {
  margin: 1px 2px;
}

.three {
  margin: 1px 2px 3px;
}

.four {
  margin: 1px 2px 3px 4px;
}

.dumb {
  margin: 1px 1px 1px 1px; // Boom: Shorthand form for property `margin` should be written more concisely as `1px` instead of `1px 1px 1px 1px`
}
```