### PR TITLE
Rubocop: Warn about class/method length

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,9 +49,6 @@ CharacterLiteral:
 ClassAndModuleChildren:
   Enabled: false
 
-ClassLength:
-  Enabled: false
-
 ClassVars:
   Enabled: false
 
@@ -132,9 +129,6 @@ LambdaCall:
   Enabled: false
 
 LineEndConcatenation:
-  Enabled: false
-
-MethodLength:
   Enabled: false
 
 ModuleFunction:


### PR DESCRIPTION
Reading the best practices, I noticed these recommendations about class and method lengths (#38):

- Prefer short, focused methods (aim for 1-liners, longer than 5 is a red flag)
- Prefer small, focused classes (100+ lines is a red flag)

To my surprise, those recommendations are disabled in our Rubocop configuration. I think we could give it a try and warn about these limits.

The default values in RuboCop are 100 lines for classes and 10 lines for methods. With these values, we currently have 10 warnings for classes and 61 for methods in `global-web`. I think it would be better to start with those default values (that's why I simply deleted those lines) because with the limit of 5 lines for methods our errors would rise to 414