### PR TITLE
Add a convention for using $stdin, $stdout, $stderr

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -5,6 +5,7 @@
 - Prefer short, focused methods (aim for 1-liners, longer than 5 is a red flag)
 - Prefer small, focused classes (100+ lines is a red flag)
 - [Prefer extracting private methods over setting variables inside methods](samples/ruby/3.rb)
+- Prefer `$stdin`, `$stdout`, `$stderr` over `STDIN`, `STDOUT`, `STDERR`
 
 ## Rails
 


### PR DESCRIPTION
Using the global `$stdout` over the constant `STDOUT`,
since other programs (like test suite) could change `$stdout`
to something else to make testing easier.

Also `STDOUT`, `STDERR`, `STDIN`'s default values are all to their `$std*` counterparts.

`$std*` docs: http://ruby-doc.org/core-2.4.2/doc/globals_rdoc.html