### PR TITLE
The cop InvalidCharacterLiteral has been removed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -262,9 +262,6 @@ ElseLayout:
 HandleExceptions:
   Enabled: false
 
-InvalidCharacterLiteral:
-  Enabled: false
-
 LiteralInCondition:
   Enabled: false
 


### PR DESCRIPTION
When trying to test the latest Rubocop version (0.51.0), it stops with this error:

```
Error: The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-cookpad-guides-master--rubocop-yml, please update it)
````

This PR removes the configuration for that cop.