### PR TITLE
 Remove settings for Style/OpMethod and Lint/LiteralInCondition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,9 +161,6 @@ NumericLiterals:
 OneLineConditional:
   Enabled: false
 
-OpMethod:
-  Enabled: false
-
 ParallelAssignment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -259,9 +259,6 @@ ElseLayout:
 HandleExceptions:
   Enabled: false
 
-LiteralInCondition:
-  Enabled: false
-
 LiteralInInterpolation:
   Enabled: false
 


### PR DESCRIPTION
When I try to run the latest version of Rubocop (0.51.0) I have found a couple of issues. The first one I have already solved [here](https://github.com/cookpad/guides/pull/63). The second refers to the `Style/OpMethod` cop, which has been renamed to `Naming/BinaryOperatorParameterName` (I don't know why this has to raise an error instead of a warning).

```
Error: The `Style/OpMethod` cop has been renamed and moved to `Naming/BinaryOperatorParameterName`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-cookpad-guides-master--rubocop-yml, please update it)
```

In our configuration we have that cop disabled. But I've checked that by leaving the default settings (i.e. _enabled_) and testing it on four of our top projects, there's a __single__ offense in `global-search`:

```
When defining the eql? operator, name its argument other.
    def eql?(node)
             ^^^^
```

My proposal is to simply delete that setting and leave the default (_enabled_), so it won't cause problems with the new versions of RuboCop. Also, I find it even good to have it turned on.

(don't worry, I'll fix `global-search` 😄)

btw: I did the tests with the command:

```
rubocop --force-default-config --only Style/OpMethod
```

---

**Update**: I then found another warning about `Lint/LiteralInCondition`.  Rubocop 0.51.0 warns:
 
```   
    Warning: unrecognized cop LiteralInCondition found in .rubocop.yml
```
    
because it has been renamed to `LiteralAsCondition`

Again, none of our projects have any offense for this cop, so I've also deleted the configuration setting and enabled it. (I also think it's useful). Added a second commit in this PR and changed the title.

