### PR TITLE
Add missing namespaces to RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,192 +16,189 @@ Metrics/LineLength:
 Rails:
   Enabled: true
 
-AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
-ActionFilter:
+Rails/ActionFilter:
   Enabled: false
 
-Alias:
+Style/Alias:
   Enabled: false
 
-ArrayJoin:
+Style/ArrayJoin:
   Enabled: false
 
-AsciiComments:
+Style/AsciiComments:
   Enabled: false
 
-AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Enabled: false
 
-Attr:
+Style/Attr:
   Enabled: false
 
-BlockNesting:
+Metrics/BlockNesting:
   Enabled: false
 
-CaseEquality:
+Style/CaseEquality:
   Enabled: false
 
-CharacterLiteral:
+Style/CharacterLiteral:
   Enabled: false
 
-ClassAndModuleChildren:
+Style/ClassAndModuleChildren:
   Enabled: false
 
-ClassLength:
+Metrics/ClassLength:
   Enabled: false
 
-ClassVars:
+Style/ClassVars:
   Enabled: false
 
-CollectionMethods:
+Style/CollectionMethods:
   PreferredMethods:
     find: false
     reduce: inject
     collect: map
     find_all: false
 
-ColonMethodCall:
+Style/ColonMethodCall:
   Enabled: false
 
-CommentAnnotation:
+Style/CommentAnnotation:
   Enabled: false
 
-CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Enabled: false
 
-Delegate:
+Rails/Delegate:
   Enabled: false
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
-DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
-DoubleNegation:
+Style/DoubleNegation:
   Enabled: false
 
-EachWithObject:
+Style/EachWithObject:
   Enabled: false
 
-EmptyLiteral:
+Style/EmptyLiteral:
   Enabled: false
 
-Encoding:
+Style/Encoding:
   Enabled: false
 
-EvenOdd:
+Style/EvenOdd:
   Enabled: false
 
-FileName:
+Naming/FileName:
   Enabled: false
 
-FlipFlop:
+Style/FlipFlop:
   Enabled: false
 
-FormatString:
+Style/FormatString:
   Enabled: false
 
-FrozenStringLiteralComment:
+Style/FrozenStringLiteralComment:
   Enabled: false
 
-GlobalVars:
+Style/GlobalVars:
   Enabled: false
 
-GuardClause:
+Style/GuardClause:
   Enabled: false
 
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Enabled: false
 
-IfWithSemicolon:
+Style/IfWithSemicolon:
   Enabled: false
 
-IndentationConsistency:
+Layout/IndentationConsistency:
   Enabled: false
 
-InlineComment:
+Style/InlineComment:
   Enabled: false
 
-Lambda:
+Style/Lambda:
   Enabled: false
 
-LambdaCall:
+Style/LambdaCall:
   Enabled: false
 
-LineEndConcatenation:
+Style/LineEndConcatenation:
   Enabled: false
 
-MethodLength:
+Metrics/MethodLength:
   Enabled: false
 
-ModuleFunction:
+Style/ModuleFunction:
   Enabled: false
 
-NegatedIf:
+Style/NegatedIf:
   Enabled: false
 
-NegatedWhile:
+Style/NegatedWhile:
   Enabled: false
 
-Next:
+Style/Next:
   Enabled: false
 
-NilComparison:
+Style/NilComparison:
   Enabled: false
 
-Not:
+Style/Not:
   Enabled: false
 
-NumericLiterals:
+Style/NumericLiterals:
   Enabled: false
 
-OneLineConditional:
+Style/OneLineConditional:
   Enabled: false
 
-ParallelAssignment:
+Style/ParallelAssignment:
   Enabled: false
 
-ParameterLists:
+Metrics/ParameterLists:
   Enabled: false
 
-PercentLiteralDelimiters:
+Style/PerlBackrefs:
   Enabled: false
 
-PerlBackrefs:
-  Enabled: false
-
-PredicateName:
+Naming/PredicateName:
   NamePrefixBlacklist:
     - is_
 
-Proc:
+Style/Proc:
   Enabled: false
 
-RaiseArgs:
+Style/RaiseArgs:
   Enabled: false
 
-RegexpLiteral:
+Style/RegexpLiteral:
   Enabled: false
 
-SelfAssignment:
+Style/SelfAssignment:
   Enabled: false
 
-SingleLineBlockParams:
+Style/SingleLineBlockParams:
   Enabled: false
 
-SingleLineMethods:
+Style/SingleLineMethods:
   Enabled: false
 
-SignalException:
+Style/SignalException:
   Enabled: false
 
-SpecialGlobalVars:
+Style/SpecialGlobalVars:
   Enabled: false
 
-StringLiterals:
+Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/TrailingCommaInLiteral:
@@ -215,72 +212,68 @@ Style/TrailingCommaInArguments:
 Style/FormatStringToken:
   EnforcedStyle: template
 
-TrivialAccessors:
+Style/TrivialAccessors:
   Enabled: false
 
-UnusedMethodArgument:
+Lint/UnusedMethodArgument:
   Enabled: false
 
-VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
-VariableInterpolation:
+Style/VariableInterpolation:
   Enabled: false
 
-WhenThen:
+Style/WhenThen:
   Enabled: false
 
-WhileUntilModifier:
+Style/WhileUntilModifier:
   Enabled: false
 
-WordArray:
+Style/WordArray:
   Enabled: false
 
-# Lint
-
-AmbiguousOperator:
+Lint/AmbiguousOperator:
   Enabled: false
 
-AmbiguousRegexpLiteral:
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-AssignmentInCondition:
+Lint/AssignmentInCondition:
   Enabled: false
 
-ConditionPosition:
+Lint/ConditionPosition:
   Enabled: false
 
-DeprecatedClassMethods:
+Lint/DeprecatedClassMethods:
   Enabled: false
 
-ElseLayout:
+Lint/ElseLayout:
   Enabled: false
 
-HandleExceptions:
+Lint/HandleExceptions:
   Enabled: false
 
-LiteralInInterpolation:
+Lint/LiteralInInterpolation:
   Enabled: false
 
-Loop:
+Lint/Loop:
   Enabled: false
 
-ParenthesesAsGroupedExpression:
+Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 
-RedundantMerge:
+Performance/RedundantMerge:
   Enabled: false
 
-RequireParentheses:
+Lint/RequireParentheses:
   Enabled: false
 
-UnderscorePrefixedVariableName:
+Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
-Void:
+Lint/Void:
   Enabled: false
-
-# Spec exceptions
 
 Lint/UselessAssignment:
   Exclude:
@@ -293,7 +286,7 @@ Layout/EmptyLines:
 Style/NumericPredicate:
   EnforcedStyle: comparison
 
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     "%":  ()
     "%i": ()


### PR DESCRIPTION
For **readability**, and to avoid future issues, I'd like to add namespaces to our configuration.

(Namespaces were introduced in RuboCop in 2014 to avoid conflicts with plugins like `rubocop_rspec`).