### PR TITLE
avoid trailing conditionals

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -6,6 +6,7 @@
 - Prefer small, focused classes (100+ lines is a red flag)
 - [Prefer extracting private methods over setting variables inside methods](samples/ruby/3.rb)
 - Prefer `$stdin`, `$stdout`, `$stderr` over `STDIN`, `STDOUT`, `STDERR`
+- [Avoid lines that end with conditionals (exception is guard clauses)](samples/ruby/4.rb)
 
 ## Rails
 

--- a/best-practices/samples/ruby/4.rb
+++ b/best-practices/samples/ruby/4.rb
@@ -1,0 +1,19 @@
+## Bad
+def run
+  mark_related_items(:spam) if spam_detected?
+end
+
+## Good
+def run
+  if spam_detected?
+    mark_related_items(:spam)
+  end
+end
+
+## OK for guard clauses, separate by space
+def approve
+  return if approved?
+  return if unapprovable?
+
+  update!(approved: true)
+end

--- a/best-practices/samples/ruby/4.rb
+++ b/best-practices/samples/ruby/4.rb
@@ -11,5 +11,5 @@ def approve
   return if approved?
   return if unapprovable?
 
-  update!(approved: true)
+  update(approved: true)
 end

--- a/best-practices/samples/ruby/4.rb
+++ b/best-practices/samples/ruby/4.rb
@@ -1,13 +1,9 @@
 ## Bad
-def run
-  mark_related_items(:spam) if spam_detected?
-end
+mark_related_items(:spam) if spam_detected?
 
 ## Good
-def run
-  if spam_detected?
-    mark_related_items(:spam)
-  end
+if spam_detected?
+  mark_related_items(:spam)
 end
 
 ## OK for guard clauses, separate by space


### PR DESCRIPTION
In general, the trailing conditional often feels like a bit of a "surprise" to me:

```ruby
UserMailer.new_photo_comment_reply(notification) if receiver_is_thread_owner?
```

It also increases line-length and kind of "hides" the conditional a bit, making the code _seem_ less "branchy" than it really is:

```ruby
if receiver_is_thread_owner?
  UserMailer.new_photo_comment_reply(notification)
end
```

One exception is perhaps guard clauses, where I think it makes sense to have them at the top for "aborting", separated by a blank line ie:

```ruby
def approve
  return if approved?
  return if unapprovable?

  update!(approved: true)
end
```

Thoughts?  I think this was originally suggested by the late halogenandtoast and I was reminded when seeing [this PR](https://github.com/cookpad/global-web/pull/6164/files#diff-54ae9546c5bd57393ed9bbc0d17a5caeR8) 😅  cc @kinopyo