### PR TITLE
Enforce request.referrer over request.referer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -309,3 +309,6 @@ Rails/Output:
 
 Rails/SkipsModelValidations:
   Enabled: false
+
+Rails/RequestReferer:
+  EnforcedStyle: referrer


### PR DESCRIPTION
## referer or referrer?

[One of the offenses](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/RequestReferer) detected by Rubocop is the consistency in the use of `request.referer` or` request.referrer` throughout the code. Rack [defines both methods](https://github.com/rack/rack/blob/b0818268fd9f4026a1b0fb205cc1060ee38a23cc/lib/rack/request.rb#L141-L142) with an alias. To know more about why the misspelled word `referer`is used, you can consult the [wikipedia](https://en.wikipedia.org/wiki/HTTP_referer#Etymology)

Checking our `global-web` project, the use of each word is quite divided:

    Referrer: 7 usages in 4 files
    Referer:  7 usages in 6 files

I have created this PR as a place to discuss our preferences. It is a pull request instead of an issue because I personally would prefer to change the default value and use `referrer` (I am a _grammar nazi_), although I understand the opposite position to maintain consistency with the HTTP specification

_What is your opinion?_

(Of course, another option would be to ignore all this and disable the Cop)