### PR TITLE
Allow all our Rails environments in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -312,3 +312,11 @@ Rails/SkipsModelValidations:
 
 Rails/RequestReferer:
   EnforcedStyle: referrer
+
+Rails/UnknownEnv:
+  Environments:
+  - production
+  - beta
+  - staging
+  - development
+  - test


### PR DESCRIPTION
[Rubocop defaults.](https://github.com/bbatsov/rubocop/blob/c3ceec9d982fa27d51c5ff8a159285b910b85013/config/default.yml#L1660-L1664)

[Example of Hound failure.](https://github.com/cookpad/global-web/pull/6555#discussion_r157256452)

![image](https://user-images.githubusercontent.com/816901/34053430-bb189760-e1be-11e7-9cee-d10cd0eea0a1.png)
