### PR TITLE
add convention for using i18n helpers in specs

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -717,6 +717,24 @@
     ```
   </details>
 
+- <a name="use-i18n"></a>
+  Use I18n helpers when clicking/asserting
+  <sup>[link](#use-i18n)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    click_link "Sign up"
+    expect(page).to have_text("Welcome!")
+
+    ## Good
+    click_link t("signups.new.signup_button")
+    expect(page).to have_text t("signups.create.welcome_message")
+    ```
+  </details>
+
 ## I18n
 
 - <a name="use-fully-qualified"></a>


### PR DESCRIPTION
This has slowly been turning into a convention so I thought it might be time to put it on paper?

While I honestly think the non-i18n version _reads_ better, I think I've come to consider it an acceptable tradeoff for the problems it solves, ie:

- Writing specs for languages you don't understand
- Avoiding specs failing due to some copywriting change

Now's a good time to comment if you have any thoughts! 🌏 