### PR TITLE
Split Style/TrailingCommaInLiteral in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,7 +201,11 @@ Style/SpecialGlobalVars:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: no_comma
 


### PR DESCRIPTION
`Style/TrailingCommaInLiteral` has been splitted into `Style/TrailingCommaInArrayLiteral` & `Style/TrailingCommaInHashLiteral`  https://github.com/bbatsov/rubocop/pull/5307