### PR TITLE
Disable MemoizedInstanceVariableName rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -302,6 +302,9 @@ Style/PercentLiteralDelimiters:
     "%W": ()
     "%x": ()
 
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
 Rails/Output:
   Enabled: true
   Include:


### PR DESCRIPTION
Latest Cop (https://github.com/bbatsov/rubocop/pull/5445) prevents us to use our current convention for writing memoized instance variable name with underscore prefix, e.g. `@_user`