### PR TITLE
Lint/ConditionPosition has the wrong namespace - should be Layout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -246,7 +246,7 @@ Lint/AmbiguousRegexpLiteral:
 Lint/AssignmentInCondition:
   Enabled: false
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Enabled: false
 
 Lint/DeprecatedClassMethods:


### PR DESCRIPTION
Now that we have updated to the latest RuboCop version we should also fix this new warning.