### PR TITLE
Best practices about memoized instance variable names

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -131,6 +131,59 @@
     ```
   </details>
 
+- <a name="memoized-instance-variable-name"></a>
+  In memoized methods, use a instance variable that matches the method name prefixed with an underscore  
+  <sup>[link](#memoized-instance-variable-name)</sup>
+
+  <details>
+    <summary>Example</summary>
+
+    ```ruby
+    ## Bad
+    def author
+      @_user ||= User.find(params[:id])
+    end
+    
+    ## Bad
+    def author
+      @author ||= User.find(params[:id])
+    end
+    
+    ## Good
+    def author
+      @_author ||= User.find(params[:id])
+    end
+    
+    ## For Rails views, if you need an instance variable assign it in the action
+    
+    ## Bad
+    class RecipesController < ApplicationController
+      def show
+        author
+      end
+    
+      private
+    
+        def author
+          @author ||= User.find(params[:id])
+        end
+    end
+    
+    ## Good
+    class RecipesController < ApplicationController
+      def show
+        @author = author
+      end
+    
+      private
+    
+        def author
+          @_author ||= User.find(params[:id])
+        end
+    end
+    ```
+  </details>
+
 ## Rails
 
 - <a name="prefer-time-current"></a>

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -132,7 +132,7 @@
   </details>
 
 - <a name="memoized-instance-variable-name"></a>
-  In memoized methods, use a instance variable that matches the method name prefixed with an underscore  
+  In memoized methods, use an instance variable that matches the method name prefixed with an underscore  
   <sup>[link](#memoized-instance-variable-name)</sup>
 
   <details>

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -153,34 +153,6 @@
     def author
       @_author ||= User.find(params[:id])
     end
-    
-    ## For Rails views, if you need an instance variable assign it in the action
-    
-    ## Bad
-    class RecipesController < ApplicationController
-      def show
-        author
-      end
-    
-      private
-    
-        def author
-          @author ||= User.find(params[:id])
-        end
-    end
-    
-    ## Good
-    class RecipesController < ApplicationController
-      def show
-        @author = author
-      end
-    
-      private
-    
-        def author
-          @_author ||= User.find(params[:id])
-        end
-    end
     ```
   </details>
 


### PR DESCRIPTION
As requested in https://github.com/cookpad/global-web/pull/7128#discussion_r178506339

Matt explained it recently in an AMA about Ruby on Twitter:

<blockquote class="twitter-tweet" data-lang="es"><p lang="en" dir="ltr">Should you begin memoization instance variables with an underscore?</p>&mdash; Eric Turner (@_etdev) <a href="https://twitter.com/_etdev/status/978526500193370114?ref_src=twsrc%5Etfw">March 27, 2018</a></blockquote>

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">I tend to use this practice to imply that the variable is meant for internal (to the method) use only. It&#39;s an easy way to distinguish it from regular instance variables. I would definitely advocate it usage for this scenario.</p>&mdash; Matthew Mongeau (@halogenandtoast) <a href="https://twitter.com/halogenandtoast/status/978527142991441921?ref_src=twsrc%5Etfw">March 27, 2018</a></blockquote>
