### PR TITLE
Update guides to reflect current conventions

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -10,32 +10,32 @@ Code review is [the discipline of explaining your code to your peers](https://ww
 
 ## Flow
 
-1. Write a description to provide context for reviewers
+1. Write a description to provide context for reviewers.
   - Why are we doing this? What's the intended outcome?
-  - For bugfixes provide screenshots / specs showing the bug
-  - For features, provide a [demo gif](http://www.cockos.com/licecap/)
-  - Provide a link to relevant GitHub issue where appropriate
-2. Fix or address any hound comments
-3. Respond to reviewer comments w/ new commits or comments
-4. Comment :recycle: after having made changes to ask for a new review
-5. Merge + deploy after receiving an approved review from at least 1 reviewer
+  - For bugfixes provide screenshots / specs showing the bug.
+  - For features, provide a [demo gif](http://www.cockos.com/licecap/).
+  - Provide a link to relevant GitHub issue where appropriate.
+2. Fix or address any hound comments.
+3. Respond to reviewer comments w/ new commits or comments.
+4. Comment :recycle: after having made changes to ask for a new review.
+5. Merge + deploy after receiving an approved review from at least 1 reviewer.
 
 ### Reviewing Code
 
 - Be aware of _negativity bias_. Ask, don't tell.
-- Identify ways to simplify the code while still solving the problem
-- Communicate which ideas you feel strongly about and those you don't
-- Consider switching to Slack/Zoom if higher bandwith communication is needed
-- Use the GitHub review tool: Only use _approve_ or _changes requested_ so your intention is clear
-- Follow up on changes you request
-- Help get the PR to a state where it can be approved
+- Identify ways to simplify the code while still solving the problem.
+- Communicate which ideas you feel strongly about and those you don't.
+- Consider switching to Slack/Zoom if higher bandwith communication is needed.
+- Use the GitHub review tool: Only use _approve_ or _changes requested_ so your intention is clear.
+- Follow up on changes you request.
+- Help get the PR to a state where it can be approved.
 
 ### Having Your Code Reviewed
 
-- Try to keep PRs focused on _one concept_
-- Keep PRs _short_, ideally 50-100 lines
-- Incomplete features are fine, for example submitting a pending spec for review is welcome
-- Be grateful for the reviewer's suggestions
+- Try to keep PRs focused on _one concept_.
+- Keep PRs _short_, ideally 50-100 lines.
+- Incomplete features are fine, for example submitting a pending spec for review is welcome.
+- Be grateful for the reviewer's suggestions.
 - Don't take it personally. The review is of the code, not you.
-- Explain why the code exists and try to rework the code so no explanation is necessary ("It's like that because of these reasons. Would it be more clear if I rename this class/file/method/variable?")
+- Explain why the code exists and try to rework the code so no explanation is necessary ("It's like that because of these reasons. Would it be more clear if I rename this class/file/method/variable?").
 - Merge only once you feel confident in the code and its impact on the project.

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -25,7 +25,7 @@ Code review is [the discipline of explaining your code to your peers](https://ww
 - Be aware of _negativity bias_. Ask, don't tell.
 - Identify ways to simplify the code while still solving the problem
 - Communicate which ideas you feel strongly about and those you don't
-- Consider switching to Slack/Call if higher bandwith communication is needed
+- Consider switching to Slack/Zoom if higher bandwith communication is needed
 - Use the GitHub review tool: Only use _approve_ or _changes requested_ so your intention is clear
 - Follow up on changes you request
 - Help get the PR to a state where it can be approved

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -11,9 +11,10 @@ Code review is [the discipline of explaining your code to your peers](https://ww
 ## Flow
 
 1. Write a description to provide context for reviewers
+  - Why are we doing this? What's the intended outcome?
   - For bugfixes provide screenshots / specs showing the bug
   - For features, provide a [demo gif](http://www.cockos.com/licecap/)
-  - Provide a link to a Trello card containing hypothesis and expected outcome
+  - Provide a link to relevant GitHub issue where appropriate
 2. Fix or address any hound comments
 3. Respond to reviewer comments w/ new commits or comments
 4. Comment :recycle: after having made changes to ask for a new review
@@ -24,14 +25,17 @@ Code review is [the discipline of explaining your code to your peers](https://ww
 - Be aware of _negativity bias_. Ask, don't tell.
 - Identify ways to simplify the code while still solving the problem
 - Communicate which ideas you feel strongly about and those you don't
-- Consider switching to Slack/Hangouts if higher bandwith communication is needed
-- Use the GitHub review tool
+- Consider switching to Slack/Call if higher bandwith communication is needed
+- Use the GitHub review tool: Only use _approve_ or _changes requested_ so your intention is clear
 - Follow up on changes you request
 - Help get the PR to a state where it can be approved
 
 ### Having Your Code Reviewed
 
-- Be grateful for the reviewer's suggestions.
+- Try to keep PRs focused on _one concept_
+- Keep PRs _short_, ideally 50-100 lines
+- Incomplete features are fine, for example submitting a pending spec for review is welcome
+- Be grateful for the reviewer's suggestions
 - Don't take it personally. The review is of the code, not you.
 - Explain why the code exists and try to rework the code so no explanation is necessary ("It's like that because of these reasons. Would it be more clear if I rename this class/file/method/variable?")
 - Merge only once you feel confident in the code and its impact on the project.

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -4,31 +4,14 @@ Ensure [cp8_cli](https://github.com/balvig/cp8_cli) is installed and up to date 
 
 ## Stories
 
-1. `cp8 start <URL>` to start work on a Trello card / GitHub issue
-2. `cp8 submit` if done to open a pull request for [code review](/code-review)
-3. If necessary, [request and update translations](https://github.com/cookpad/global-web/blob/master/docs/operations.md#translations)
-4. After completing code review merge in GitHub and _deploy_
+1. `cp8 start <URL>` to start work on a GitHub issue
+2. `cp8 start "Title of story"` to start an adhoc story
+3. `cp8 open` to open associated WIP pull request
+4. Remove [WIP] from title when ready for [code review](/code-review)
+5. If necessary, [request and update translations](https://github.com/cookpad/global-web/blob/master/docs/operations.md#translations)
+6. After completing code review merge in GitHub and _deploy_
 
 **NOTE:** It is vital to deploy right after merging new code, so that _you_ can follow up on any bugs/issues, instead of it becoming the problem of the next person to deploy.
-
-## WIP branches
-
-It can often be helpful to start _early_ with a WIP pull request to get
-initial feedback.
-
-1. `cp8 submit --wip` to submit a WIP pull request early to ask for help or feedback
-2. Remove [WIP] from title when ready for final review
-
-## Bigger releases ("epics")
-
-For bigger features that consist of multiple stories that need to be released together, create a _release
-branch_.  Reviewers will then be able to review each _smaller_ PR as they come in.
-
-1. `git co -b my_new_epic` to start a release branch
-2. `git commit -m'init commit' --allow-empty` to add an empty commit
-3. `git push -u origin my_new_epic` to push to GitHub
-4. Create a PR from the new branch with information about the feature
-5. Running `cp8 start` and `cp8 submit` from a release branch will automatically target that branch instead of master
 
 ## Discussions and ideas around development
 
@@ -38,4 +21,3 @@ New ideas on how we can improve our development flow are always welcome!
 - When proposing a change or new concept, submit an issue or isolated PR on GitHub
 - Clearly show the before/after and any pain points that inspired the proposal
 - Allow the issue or PR to sit long enough for everyone to have a look
-- The [Developer Happiness Squad](https://github.com/cookpad/developer-happiness-squad) is a good place to go to submit ideas for improvements


### PR DESCRIPTION
Mainly:

- GitHub issues > ~Trello~
- Mention "approve or request changes", no in between
- Mention short, focused PRs
- Update `cp8` usage
- Remove mention on `WIP` branches as this is now built-in to `cp8`
- Remove section on release branches, these are no longer encouraged (although sometimes unavoidable), PRs should target `master` as much as possible
- Remove using "Dev Happiness Squad" as a place to collect technical suggestions, `global-web` should be fine?