### PR TITLE
Use minutes not second when asserting results order

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -829,6 +829,30 @@
     expect(page).to have_text t("signups.create.welcome_message")
     ```
   </details>
+  
+  - <a name="use-minutes"></a>
+  Use minutes instead of second when a setting timestamps to asserting on results order
+  <sup>[link](#use-minutes)</sup>
+
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```ruby
+    ## Bad
+    older_recipe = create(:recipe, published_at: 2.seconds.ago)
+    newest_recipe = create(:recipe, published_at: 1.second.ago)
+    
+    expect(Recipe.recently_published.first).to eq(newest_recipe)
+    expect(Recipe.recently_published.last).to eq(older_recipe)
+
+    ## Good
+    older_recipe = create(:recipe, published_at: 2.minutes.ago)
+    newest_recipe = create(:recipe, published_at: 1.minute.ago)
+    
+    expect(Recipe.recently_published.first).to eq(newest_recipe)
+    expect(Recipe.recently_published.last).to eq(older_recipe)
+    ```
+  </details>
 
 ## I18n
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -838,7 +838,7 @@
     <summary><em>Example</em></summary>
 
     ```ruby
-    ## Bad
+    ## Bad: Causes random failures depending on the timing of each step
     older_recipe = create(:recipe, published_at: 2.seconds.ago)
     newest_recipe = create(:recipe, published_at: 1.second.ago)
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -831,7 +831,7 @@
   </details>
   
 - <a name="use-minutes"></a>
-  Use minutes instead of second when a setting timestamps to asserting on results order
+  Use minutes instead of seconds when setting timestamps for the purpose of asserting the order of results
   <sup>[link](#use-minutes)</sup>
 
   <details>

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -831,28 +831,28 @@
   </details>
   
   - <a name="use-minutes"></a>
-  Use minutes instead of second when a setting timestamps to asserting on results order
-  <sup>[link](#use-minutes)</sup>
+    Use minutes instead of second when a setting timestamps to asserting on results order
+    <sup>[link](#use-minutes)</sup>
 
-  <details>
-    <summary><em>Example</em></summary>
+    <details>
+      <summary><em>Example</em></summary>
 
-    ```ruby
-    ## Bad
-    older_recipe = create(:recipe, published_at: 2.seconds.ago)
-    newest_recipe = create(:recipe, published_at: 1.second.ago)
-    
-    expect(Recipe.recently_published.first).to eq(newest_recipe)
-    expect(Recipe.recently_published.last).to eq(older_recipe)
+      ```ruby
+      ## Bad
+      older_recipe = create(:recipe, published_at: 2.seconds.ago)
+      newest_recipe = create(:recipe, published_at: 1.second.ago)
 
-    ## Good
-    older_recipe = create(:recipe, published_at: 2.minutes.ago)
-    newest_recipe = create(:recipe, published_at: 1.minute.ago)
-    
-    expect(Recipe.recently_published.first).to eq(newest_recipe)
-    expect(Recipe.recently_published.last).to eq(older_recipe)
-    ```
-  </details>
+      expect(Recipe.recently_published.first).to eq(newest_recipe)
+      expect(Recipe.recently_published.last).to eq(older_recipe)
+
+      ## Good
+      older_recipe = create(:recipe, published_at: 2.minutes.ago)
+      newest_recipe = create(:recipe, published_at: 1.minute.ago)
+
+      expect(Recipe.recently_published.first).to eq(newest_recipe)
+      expect(Recipe.recently_published.last).to eq(older_recipe)
+      ```
+    </details>
 
 ## I18n
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -830,29 +830,29 @@
     ```
   </details>
   
-  - <a name="use-minutes"></a>
-    Use minutes instead of second when a setting timestamps to asserting on results order
-    <sup>[link](#use-minutes)</sup>
+- <a name="use-minutes"></a>
+  Use minutes instead of second when a setting timestamps to asserting on results order
+  <sup>[link](#use-minutes)</sup>
 
-    <details>
-      <summary><em>Example</em></summary>
+  <details>
+    <summary><em>Example</em></summary>
 
-      ```ruby
-      ## Bad
-      older_recipe = create(:recipe, published_at: 2.seconds.ago)
-      newest_recipe = create(:recipe, published_at: 1.second.ago)
+    ```ruby
+    ## Bad
+    older_recipe = create(:recipe, published_at: 2.seconds.ago)
+    newest_recipe = create(:recipe, published_at: 1.second.ago)
 
-      expect(Recipe.recently_published.first).to eq(newest_recipe)
-      expect(Recipe.recently_published.last).to eq(older_recipe)
+    expect(Recipe.recently_published.first).to eq(newest_recipe)
+    expect(Recipe.recently_published.last).to eq(older_recipe)
 
-      ## Good
-      older_recipe = create(:recipe, published_at: 2.minutes.ago)
-      newest_recipe = create(:recipe, published_at: 1.minute.ago)
+    ## Good
+    older_recipe = create(:recipe, published_at: 2.minutes.ago)
+    newest_recipe = create(:recipe, published_at: 1.minute.ago)
 
-      expect(Recipe.recently_published.first).to eq(newest_recipe)
-      expect(Recipe.recently_published.last).to eq(older_recipe)
-      ```
-    </details>
+    expect(Recipe.recently_published.first).to eq(newest_recipe)
+    expect(Recipe.recently_published.last).to eq(older_recipe)
+    ```
+  </details>
 
 ## I18n
 


### PR DESCRIPTION
This is a follow-up to a discussion started in https://github.com/cookpad/global-web/pull/7716#pullrequestreview-116719537

In order to avoid flaky tests that fail based on the second the test gets executed as explained by @karlentwistle in the image below:

![](https://user-images.githubusercontent.com/666397/39517872-22dcffc0-4df9-11e8-8a84-eaab01a3a322.JPG)

We should consistently use minutes, another option as mentioned by @knack before would be to freeze time.