### PR TITLE
Prefer 3.times.map over Array.new(3).map

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -270,6 +270,9 @@ Lint/ParenthesesAsGroupedExpression:
 Performance/RedundantMerge:
   Enabled: false
 
+Performance/TimesMap:
+  Enabled: false
+
 Lint/RequireParentheses:
   Enabled: false
 


### PR DESCRIPTION
Context https://github.com/cookpad/global-web/pull/7808#issuecomment-387919152

Disable https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Performance/TimesMap

I prefer the readability of `3.times.map { |x| }` over `Array.new(3).map { |x| }`.

More discussion: 
https://stackoverflow.com/questions/41518896/why-does-rubocop-suggest-replacing-times-map-with-array-new