### PR TITLE
Avoid HTML in locale file

### DIFF
--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -868,9 +868,9 @@
   Don't use `zero:` key to display a "no results" message (it is intended only to allow proper grammar)
   <sup>[link](#dont-abuse-zero-key)</sup>
 
-- <a name="avoid-html-in-locale"></a>
-  Avoid including HTML in locale file
-  <sup>[link](#avoid-html-in-locale)</sup>
+- <a name="dont-html-in-locale"></a>
+  Don't include HTML in locale file
+  <sup>[link](#dont-html-in-locale)</sup>
   
   <details>
     <summary><em>Example</em></summary>

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -868,6 +868,36 @@
   Don't use `zero:` key to display a "no results" message (it is intended only to allow proper grammar)
   <sup>[link](#dont-abuse-zero-key)</sup>
 
+- <a name="avoid-html-in-locale"></a>
+  Avoid including HTML in locale file
+  <sup>[link](#avoid-html-in-locale)</sup>
+  
+  <details>
+    <summary><em>Example</em></summary>
+
+    ```yml
+    ## Bad
+    current_time_html: "<strong>Current time:</strong> %{time}"
+    ```
+
+    ```erb
+    <!-- Bad -->
+    <%= t("current_time_html", time: Time.current) %>
+    ```
+
+    ```yml
+    ## Good
+    current_time:
+      label: "Current time:"
+      label_time: "%{label} %{time}"
+    ```
+
+    ```erb
+    <!-- Good -->
+    <%= t("current_time_html", label: content_tag(:strong, t("current_time_label")), time: Time.current) %>
+    ```
+  </details>
+
 ## Database operations
 
 - <a name="use-one-offs"></a>

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -894,7 +894,7 @@
 
     ```erb
     <!-- Good -->
-    <%= t("current_time_html", label: content_tag(:strong, t("current_time_label")), time: Time.current) %>
+    <%= t("current_time.label_time", label: content_tag(:strong, t("current_time.label")), time: Time.current) %>
     ```
   </details>
 


### PR DESCRIPTION
@balvig referring to our discussion in https://github.com/cookpad/global-web/pull/8143#discussion_r192950014

This suggests to avoid including HTML tags in translations. HTML tags increases weariness of translators, who is often unfamiliar with it.

Even though the example is coming from Admin land where there is no active translations going on, this suggestion would be good in general projects. 